### PR TITLE
FC-1090 Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+references:
+  docker_auth: &docker_auth
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_PASSWORD
+
+  docker_image_ruby: &docker_image_ruby
+    image: cimg/ruby:3.0.3
+    <<: *docker_auth
+
+  docker_container_ruby: &docker_container_ruby
+    docker:
+      - *docker_image_ruby
+    working_directory: ~/repo
+
+version: 2.1
+
+jobs:
+  build:
+    <<: *docker_container_ruby
+
+    steps:
+      - checkout
+      - run:
+          name: Configure Bundler
+          command: |
+            export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+            gem install bundler -v $BUNDLER_VERSION
+
+      - run:
+          name: Install gems
+          command: bundle install --jobs=4 --retry=3
+
+      - run:
+          name: Run Ruby tests
+          command: bundle exec rake test
+
+      - store_test_results:
+          path: /tmp/test-results
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,24 @@
+PATH
+  remote: .
+  specs:
+    memoist (0.16.2.everfi.1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark-ips (2.10.0)
+    minitest (5.16.3)
+    rake (13.0.6)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  benchmark-ips
+  bundler
+  memoist!
+  minitest (~> 5.10)
+  rake
+
+BUNDLED WITH
+   2.3.22


### PR DESCRIPTION
https://everfi.atlassian.net/browse/FC-1090

This is a simple CircleCI config without gem release step

I don't foresee the need for releasing new gem versions for a while (likely only needed for compatibility issues with new ruby and rails releases) but let me know if it would be better to include gem release step similar as private gem repos like: https://github.com/EverFi/everfi_json_api_client/blob/master/.circleci/config.yml